### PR TITLE
Improve site layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
-## Digitalized Home
+# Digitalized Home
 
+A personal portfolio built with Next.js and Tailwind CSS.
+
+## Development
+
+Install dependencies and start the development server:
+
+```bash
+npm install
+npm run dev
+```
+
+## Production build
+
+```bash
+npm run build
+npm start
+```

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -7,27 +7,18 @@ import Link from "next/link";
 export default function Blog() {
   const posts = [
     {
-      title: "Placeholder Title 1",
-      excerpt:
-        "This is a placeholder excerpt for the first blog post...",
+      title: "Introducing the Blog",
+      excerpt: "Short updates and articles will appear here soon.",
       date: "2024-01-01",
-      readTime: "5 min read",
-      tags: ["Placeholder", "Example"],
-    },
-    { 
-      title: "Placeholder Title 2",
-      excerpt:
-        "This is a placeholder excerpt for the second blog post...",
-      date: "2024-01-02",
-      readTime: "7 min read",
-      tags: ["Placeholder", "Example"],
+      readTime: "2 min read",
+      tags: ["Announcement"],
     },
   ];
 
   return (
     <div className="space-y-8">
       <div className="space-y-2">
-        <h1 className="text-4xl font-bold text-blue-400">blog</h1>
+        <h1 className="text-4xl font-bold text-blue-400">Blog</h1>
         <div className="h-1 w-20 bg-blue-500/50 rounded-full" />
       </div>
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -17,5 +17,4 @@
 body {
   color: var(--foreground);
   background: var(--background);
-  font-family: "Courier New", Courier, monospace;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,8 +2,9 @@
 
 import "./globals.css";
 import { Inter } from "next/font/google";
-import { useRouter, usePathname } from "next/navigation";
-import { useEffect } from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { cn } from "@/lib/utils";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -12,65 +13,39 @@ export default function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
-  const router = useRouter();
   const pathname = usePathname();
 
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      const key = e.key.toLowerCase();
-      switch (key) {
-        case "m":
-          router.push("/");
-          break;
-        case "p":
-          router.push("/projects");
-          break;
-        case "b":
-          router.push("/blog");
-          break;
-      }
-    };
-
-    window.addEventListener("keydown", handleKeyDown);
-    return () => {
-      window.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [router]);
-
   const navItems = [
-    { key: "M", href: "/", label: "Me" },
-    { key: "P", href: "/projects", label: "Projects" },
-    { key: "B", href: "/blog", label: "Blog" },
+    { href: "/", label: "Me" },
+    { href: "/projects", label: "Projects" },
+    { href: "/blog", label: "Blog" },
   ];
 
   return (
     <html lang="en">
-      <body
-        className={`${inter.className} min-h-screen bg-background font-mono`}
-        style={{ fontFamily: "Source Code Pro, monospace" }}
-      >
-        <div className="fixed left-6 top-1/2 -translate-y-1/2 space-y-4 z-50">
-          {navItems.map(({ key, href, label }) => (
-            <button
-              key={key}
-              onClick={() => router.push(href)}
-              className={`group relative flex h-12 w-12 items-center justify-center rounded-md border-2 border-primary bg-background font-mono text-xl text-blue-600 font-bold shadow-lg transition-all ${
-                pathname === href ? "bg-primary text-primary-foreground" : ""
-              }`}
-            >
-              {key}
-              {pathname === href && (
-                <span className="absolute -right-1 -top-1 h-3 w-3 rounded-full bg-secondary" />
-              )}
-              <span className="absolute left-full ml-2 hidden rounded-md bg-secondary px-2 py-1 text-sm opacity-0 transition-opacity group-hover:opacity-100 lg:block">
-                {label}
-              </span>
-            </button>
-          ))}
-        </div>
-        <div className="flex min-h-screen items-center justify-center">
-          <main className="mx-auto max-w-4xl space-y-12 p-6">{children}</main>
-        </div>
+      <body className={`${inter.className} min-h-screen bg-background`}>
+        <header className="sticky top-0 z-40 border-b bg-background/80 backdrop-blur">
+          <div className="mx-auto flex max-w-4xl items-center justify-between p-4">
+            <Link href="/" className="font-semibold">
+              Matthew Singer
+            </Link>
+            <nav className="flex gap-4 text-sm">
+              {navItems.map(({ href, label }) => (
+                <Link
+                  key={href}
+                  href={href}
+                  className={cn(
+                    "transition-colors hover:text-blue-600",
+                    pathname === href ? "text-blue-600" : "text-muted-foreground"
+                  )}
+                >
+                  {label}
+                </Link>
+              ))}
+            </nav>
+          </div>
+        </header>
+        <main className="mx-auto max-w-4xl p-6">{children}</main>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -36,9 +36,6 @@ export default function Home() {
     <>
       <div className="space-y-12">
         <header className="relative flex flex-col items-center space-y-4 text-center">
-          <p className="max-w-2xl text-sm font-extrabold text-blue-400/80">
-            controls {"<>"} M (me), P (projects), and B (blog)
-          </p>
           <h1 className="text-6xl font-bold">
             <span className="bg-gradient-to-r from-blue-400 to-blue-600 bg-clip-text text-transparent">
               Matthew Singer
@@ -68,7 +65,7 @@ export default function Home() {
               href={href}
               className="text-muted-foreground hover:text-foreground"
             >
-              <Icon className="h-6 w-6 text-blue-400" /> {/* Changed color to blue */}
+              <Icon className="h-6 w-6 text-blue-400" />
               <span className="sr-only">{label}</span>
             </a>
           ))}

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -26,7 +26,7 @@ export default function Projects() {
   return (
     <div className="space-y-8">
       <div className="space-y-2">
-        <h1 className="text-4xl font-bold text-blue-400">projects</h1>
+        <h1 className="text-4xl font-bold text-blue-400">Projects</h1>
         <div className="h-1 w-20 bg-blue-500/50 rounded-full" />
       </div>
 


### PR DESCRIPTION
## Summary
- modernize layout with sticky header navigation
- remove keyboard-based controls and monospaced font
- clean up home page and update blog post placeholders
- tweak section titles for a professional look
- document development commands in README

## Testing
- `npm install`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_683f458c99bc8329a7628428cf3a9220